### PR TITLE
feat(mobile): Allow user to interact with counters or navigate to counter details from counters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This project relies on [flutter_localizations][flutter_localizations_link] and f
 - [X] Add Readme
 - [X] Add License file
 - [X] Add Changelog
-- [ ] Toggle mode for counters list to either manipulate counters or scroll the list
+- [X] Toggle mode for counters list to either manipulate counters or scroll the list
 - [ ] Edit counter
 	- [ ] Name
  	- [ ] Reset back to 0

--- a/coverage_badge.svg
+++ b/coverage_badge.svg
@@ -12,7 +12,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="30" y="14" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="13">coverage</text>
-    <text x="71" y="14" fill="#010101" fill-opacity=".3">90%</text>
-    <text x="71" y="13">90%</text>
+    <text x="71" y="14" fill="#010101" fill-opacity=".3">91%</text>
+    <text x="71" y="13">91%</text>
   </g>
 </svg>

--- a/lib/data_source/counter/model/data_source_counter.g.dart
+++ b/lib/data_source/counter/model/data_source_counter.g.dart
@@ -7,8 +7,7 @@ part of 'data_source_counter.dart';
 // **************************************************************************
 
 _$DataSourceCounterImpl _$$DataSourceCounterImplFromJson(
-  Map<String, dynamic> json,
-) =>
+        Map<String, dynamic> json) =>
     _$DataSourceCounterImpl(
       id: json['id'] as String,
       name: json['name'] as String,
@@ -16,8 +15,7 @@ _$DataSourceCounterImpl _$$DataSourceCounterImplFromJson(
     );
 
 Map<String, dynamic> _$$DataSourceCounterImplToJson(
-  _$DataSourceCounterImpl instance,
-) =>
+        _$DataSourceCounterImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,

--- a/lib/data_source/counter/model/data_source_counter.g.dart
+++ b/lib/data_source/counter/model/data_source_counter.g.dart
@@ -7,7 +7,8 @@ part of 'data_source_counter.dart';
 // **************************************************************************
 
 _$DataSourceCounterImpl _$$DataSourceCounterImplFromJson(
-        Map<String, dynamic> json) =>
+  Map<String, dynamic> json,
+) =>
     _$DataSourceCounterImpl(
       id: json['id'] as String,
       name: json['name'] as String,
@@ -15,7 +16,8 @@ _$DataSourceCounterImpl _$$DataSourceCounterImplFromJson(
     );
 
 Map<String, dynamic> _$$DataSourceCounterImplToJson(
-        _$DataSourceCounterImpl instance) =>
+  _$DataSourceCounterImpl instance,
+) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,

--- a/lib/di/injectable/configure_injectable.config.dart
+++ b/lib/di/injectable/configure_injectable.config.dart
@@ -9,11 +9,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:boring_counter/config/app/app_config.dart' as _i3;
-import 'package:boring_counter/config/app/dev_app_config.dart' as _i4;
-import 'package:boring_counter/config/app/prod_app_config.dart' as _i5;
+import 'package:boring_counter/config/app/dev_app_config.dart' as _i5;
+import 'package:boring_counter/config/app/prod_app_config.dart' as _i4;
 import 'package:boring_counter/config/app/staging_app_config.dart' as _i6;
 import 'package:boring_counter/data_source/analytics/analytics_tracker.dart'
-    as _i27;
+    as _i26;
 import 'package:boring_counter/data_source/analytics/default_analytics_repository.dart'
     as _i31;
 import 'package:boring_counter/data_source/analytics/trackers/firebase_analytics_tracker.dart'
@@ -29,7 +29,7 @@ import 'package:boring_counter/data_source/counter/repository/stream_provider.da
 import 'package:boring_counter/data_source/crashlytics/default_crashlytics_repository.dart'
     as _i35;
 import 'package:boring_counter/data_source/crashlytics/error_tracker.dart'
-    as _i26;
+    as _i27;
 import 'package:boring_counter/data_source/crashlytics/trackers/firebase_error_tracker.dart'
     as _i12;
 import 'package:boring_counter/data_source/crashlytics/trackers/std_out_error_tracker.dart'
@@ -75,9 +75,9 @@ import 'package:logger/logger.dart' as _i13;
 import 'package:shared_preferences/shared_preferences.dart' as _i14;
 import 'package:uuid/uuid.dart' as _i20;
 
-const String _development = 'development';
-const String _production = 'production';
 const String _staging = 'staging';
+const String _production = 'production';
+const String _development = 'development';
 
 // initializes the registration of main-scope dependencies inside of GetIt
 Future<_i1.GetIt> init(
@@ -94,12 +94,12 @@ Future<_i1.GetIt> init(
   final crashlyticsModule = _$CrashlyticsModule();
   final genericModule = _$GenericModule();
   gh.factory<_i3.AppConfig>(
-    () => _i4.DevelopmentAppConfig(),
-    registerFor: {_development},
+    () => _i4.ProductionAppConfig(),
+    registerFor: {_production},
   );
   gh.factory<_i3.AppConfig>(
-    () => _i5.ProductionAppConfig(),
-    registerFor: {_production},
+    () => _i5.DevelopmentAppConfig(),
+    registerFor: {_development},
   );
   gh.factory<_i3.AppConfig>(
     () => _i6.StagingAppConfig(),
@@ -150,23 +150,23 @@ Future<_i1.GetIt> init(
       _i24.DecrementCounterUseCase(repository: gh<_i21.CounterRepository>()));
   gh.factory<_i25.IncrementCounterUseCase>(() =>
       _i25.IncrementCounterUseCase(repository: gh<_i21.CounterRepository>()));
-  gh.factory<List<_i26.ErrorTracker>>(() => crashlyticsModule.getErrorTrackers(
-        gh<_i3.AppConfig>(),
-        gh<_i12.FirebaseErrorTracker>(),
-        gh<_i17.StdOutErrorTracker>(),
-      ));
-  gh.factory<List<_i27.AnalyticsTracker>>(
+  gh.factory<List<_i26.AnalyticsTracker>>(
       () => analyticsModule.getAnalyticsTrackers(
             gh<_i3.AppConfig>(),
             gh<_i10.FirebaseAnalyticsTracker>(),
             gh<_i16.StdOutAnalyticsTracker>(),
           ));
+  gh.factory<List<_i27.ErrorTracker>>(() => crashlyticsModule.getErrorTrackers(
+        gh<_i3.AppConfig>(),
+        gh<_i12.FirebaseErrorTracker>(),
+        gh<_i17.StdOutErrorTracker>(),
+      ));
   gh.factory<_i28.WatchCounterUseCase>(
       () => _i28.WatchCounterUseCase(repository: gh<_i21.CounterRepository>()));
   gh.factory<_i29.WatchCountersUseCase>(() =>
       _i29.WatchCountersUseCase(repository: gh<_i21.CounterRepository>()));
   gh.factory<_i30.AnalyticsRepository>(() => _i31.DefaultAnalyticsRepository(
-      trackers: gh<List<_i27.AnalyticsTracker>>()));
+      trackers: gh<List<_i26.AnalyticsTracker>>()));
   gh.factory<_i32.CounterCubit>(
     () => _i32.CounterCubit(
       watchCounterUseCase: gh<_i21.WatchCounterUseCase>(),
@@ -195,7 +195,7 @@ Future<_i1.GetIt> init(
   );
   gh.factory<_i34.CrashlyticsRepository>(() =>
       _i35.DefaultCrashlyticsRepository(
-          trackers: gh<List<_i26.ErrorTracker>>()));
+          trackers: gh<List<_i27.ErrorTracker>>()));
   gh.factory<_i36.ErrorTrackerUseCase>(() => _i36.ErrorTrackerUseCase(
       crashlyticsRepository: gh<_i34.CrashlyticsRepository>()));
   gh.factory<_i37.EventTrackerUseCase>(() => _i37.EventTrackerUseCase(

--- a/lib/presentation/counter/view/counter_page.dart
+++ b/lib/presentation/counter/view/counter_page.dart
@@ -52,16 +52,16 @@ class CounterView extends StatelessWidget {
               : const MissingCounter(),
         ),
       ),
-      floatingActionButton: Column(
+      floatingActionButton: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          IncrementButton(
-            onPressed: () => context.read<CounterCubit>().increment(),
-          ),
-          const SizedBox(height: _buttonsDistance),
           DecrementButton(
             onPressed: () => context.read<CounterCubit>().decrement(),
+          ),
+          const SizedBox(width: _buttonsDistance),
+          IncrementButton(
+            onPressed: () => context.read<CounterCubit>().increment(),
           ),
         ],
       ),

--- a/lib/presentation/counter_list/cubit/counter_list_cubit.dart
+++ b/lib/presentation/counter_list/cubit/counter_list_cubit.dart
@@ -79,6 +79,8 @@ class CounterListCubit extends Cubit<CounterListState> {
           isCounterOnTapDisabled: !readyState.isCounterOnTapDisabled,
         ),
       );
+    } else {
+      emit(state);
     }
   }
 

--- a/lib/presentation/counter_list/cubit/counter_list_cubit.dart
+++ b/lib/presentation/counter_list/cubit/counter_list_cubit.dart
@@ -54,9 +54,12 @@ class CounterListCubit extends Cubit<CounterListState> {
           ),
         )
         .toList();
+    final isCounterOnTapDisabled =
+        state is ReadyState && (state as ReadyState).isCounterOnTapDisabled;
     emit(
       CounterListState.ready(
         counters: uiCounters,
+        isCounterOnTapDisabled: isCounterOnTapDisabled,
       ),
     );
   }
@@ -67,6 +70,17 @@ class CounterListCubit extends Cubit<CounterListState> {
       createCounterUseCase.create(
         name: name,
       );
+
+  Future<void> toggleCounterOnTapDisabled() async {
+    if (state is ReadyState) {
+      final readyState = state as ReadyState;
+      emit(
+        readyState.copyWith(
+          isCounterOnTapDisabled: !readyState.isCounterOnTapDisabled,
+        ),
+      );
+    }
+  }
 
   Future<void> incrementCounter({
     required int counterIndex,

--- a/lib/presentation/counter_list/cubit/counter_list_state.dart
+++ b/lib/presentation/counter_list/cubit/counter_list_state.dart
@@ -10,5 +10,6 @@ class CounterListState with _$CounterListState {
   }) = _LoadingState;
   const factory CounterListState.ready({
     required List<UiCounter> counters,
+    required bool isCounterOnTapDisabled,
   }) = ReadyState;
 }

--- a/lib/presentation/counter_list/cubit/counter_list_state.freezed.dart
+++ b/lib/presentation/counter_list/cubit/counter_list_state.freezed.dart
@@ -20,19 +20,23 @@ mixin _$CounterListState {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(List<UiCounter> counters) loading,
-    required TResult Function(List<UiCounter> counters) ready,
+    required TResult Function(
+            List<UiCounter> counters, bool isCounterOnTapDisabled)
+        ready,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(List<UiCounter> counters)? loading,
-    TResult? Function(List<UiCounter> counters)? ready,
+    TResult? Function(List<UiCounter> counters, bool isCounterOnTapDisabled)?
+        ready,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(List<UiCounter> counters)? loading,
-    TResult Function(List<UiCounter> counters)? ready,
+    TResult Function(List<UiCounter> counters, bool isCounterOnTapDisabled)?
+        ready,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -168,7 +172,9 @@ class _$LoadingStateImpl implements _LoadingState {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(List<UiCounter> counters) loading,
-    required TResult Function(List<UiCounter> counters) ready,
+    required TResult Function(
+            List<UiCounter> counters, bool isCounterOnTapDisabled)
+        ready,
   }) {
     return loading(counters);
   }
@@ -177,7 +183,8 @@ class _$LoadingStateImpl implements _LoadingState {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(List<UiCounter> counters)? loading,
-    TResult? Function(List<UiCounter> counters)? ready,
+    TResult? Function(List<UiCounter> counters, bool isCounterOnTapDisabled)?
+        ready,
   }) {
     return loading?.call(counters);
   }
@@ -186,7 +193,8 @@ class _$LoadingStateImpl implements _LoadingState {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(List<UiCounter> counters)? loading,
-    TResult Function(List<UiCounter> counters)? ready,
+    TResult Function(List<UiCounter> counters, bool isCounterOnTapDisabled)?
+        ready,
     required TResult orElse(),
   }) {
     if (loading != null) {
@@ -247,7 +255,7 @@ abstract class _$$ReadyStateImplCopyWith<$Res>
       __$$ReadyStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({List<UiCounter> counters});
+  $Res call({List<UiCounter> counters, bool isCounterOnTapDisabled});
 }
 
 /// @nodoc
@@ -262,12 +270,17 @@ class __$$ReadyStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? counters = null,
+    Object? isCounterOnTapDisabled = null,
   }) {
     return _then(_$ReadyStateImpl(
       counters: null == counters
           ? _value._counters
           : counters // ignore: cast_nullable_to_non_nullable
               as List<UiCounter>,
+      isCounterOnTapDisabled: null == isCounterOnTapDisabled
+          ? _value.isCounterOnTapDisabled
+          : isCounterOnTapDisabled // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -275,7 +288,9 @@ class __$$ReadyStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$ReadyStateImpl implements ReadyState {
-  const _$ReadyStateImpl({required final List<UiCounter> counters})
+  const _$ReadyStateImpl(
+      {required final List<UiCounter> counters,
+      required this.isCounterOnTapDisabled})
       : _counters = counters;
 
   final List<UiCounter> _counters;
@@ -287,8 +302,11 @@ class _$ReadyStateImpl implements ReadyState {
   }
 
   @override
+  final bool isCounterOnTapDisabled;
+
+  @override
   String toString() {
-    return 'CounterListState.ready(counters: $counters)';
+    return 'CounterListState.ready(counters: $counters, isCounterOnTapDisabled: $isCounterOnTapDisabled)';
   }
 
   @override
@@ -296,12 +314,14 @@ class _$ReadyStateImpl implements ReadyState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ReadyStateImpl &&
-            const DeepCollectionEquality().equals(other._counters, _counters));
+            const DeepCollectionEquality().equals(other._counters, _counters) &&
+            (identical(other.isCounterOnTapDisabled, isCounterOnTapDisabled) ||
+                other.isCounterOnTapDisabled == isCounterOnTapDisabled));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_counters));
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(_counters), isCounterOnTapDisabled);
 
   @JsonKey(ignore: true)
   @override
@@ -313,29 +333,33 @@ class _$ReadyStateImpl implements ReadyState {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(List<UiCounter> counters) loading,
-    required TResult Function(List<UiCounter> counters) ready,
+    required TResult Function(
+            List<UiCounter> counters, bool isCounterOnTapDisabled)
+        ready,
   }) {
-    return ready(counters);
+    return ready(counters, isCounterOnTapDisabled);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(List<UiCounter> counters)? loading,
-    TResult? Function(List<UiCounter> counters)? ready,
+    TResult? Function(List<UiCounter> counters, bool isCounterOnTapDisabled)?
+        ready,
   }) {
-    return ready?.call(counters);
+    return ready?.call(counters, isCounterOnTapDisabled);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(List<UiCounter> counters)? loading,
-    TResult Function(List<UiCounter> counters)? ready,
+    TResult Function(List<UiCounter> counters, bool isCounterOnTapDisabled)?
+        ready,
     required TResult orElse(),
   }) {
     if (ready != null) {
-      return ready(counters);
+      return ready(counters, isCounterOnTapDisabled);
     }
     return orElse();
   }
@@ -373,11 +397,13 @@ class _$ReadyStateImpl implements ReadyState {
 }
 
 abstract class ReadyState implements CounterListState {
-  const factory ReadyState({required final List<UiCounter> counters}) =
-      _$ReadyStateImpl;
+  const factory ReadyState(
+      {required final List<UiCounter> counters,
+      required final bool isCounterOnTapDisabled}) = _$ReadyStateImpl;
 
   @override
   List<UiCounter> get counters;
+  bool get isCounterOnTapDisabled;
   @override
   @JsonKey(ignore: true)
   _$$ReadyStateImplCopyWith<_$ReadyStateImpl> get copyWith =>

--- a/lib/presentation/counter_list/view/counter_item_widget.dart
+++ b/lib/presentation/counter_list/view/counter_item_widget.dart
@@ -4,12 +4,52 @@ import 'package:boring_counter/routing/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 
-// TODO(daniel): refactor
 class CounterItemWidget extends StatelessWidget {
   const CounterItemWidget({
     required this.counter,
+    this.isOnTapDisabled = false,
     super.key,
   });
+
+  final UiCounter counter;
+  final bool isOnTapDisabled;
+
+  @override
+  Widget build(BuildContext context) => isOnTapDisabled
+      ? _CounterCard(
+          counter: counter,
+        )
+      : InkWell(
+          onTap: () => openCounterDetails(context),
+          child: _CounterCard(
+            counter: counter,
+          ),
+        );
+
+  void openCounterDetails(BuildContext context) {
+    final deviceType = getDeviceType(
+      MediaQuery.of(context).size,
+    );
+    final route = CounterRoute(
+      counterId: counter.id,
+    );
+    switch (deviceType) {
+      case DeviceScreenType.mobile:
+        context.tabsRouter.navigate(
+          route,
+        );
+        break;
+
+      // ignore: no_default_cases
+      default:
+        context.router.replace(route);
+        break;
+    }
+  }
+}
+
+class _CounterCard extends StatelessWidget {
+  const _CounterCard({required this.counter});
 
   final UiCounter counter;
 
@@ -17,66 +57,44 @@ class CounterItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final captionStyle =
         Theme.of(context).textTheme.bodySmall ?? const TextStyle();
-    return InkWell(
-      onTap: () {
-        final deviceType = getDeviceType(
-          MediaQuery.of(context).size,
-        );
-        final route = CounterRoute(
-          counterId: counter.id,
-        );
-        switch (deviceType) {
-          case DeviceScreenType.mobile:
-            context.tabsRouter.navigate(
-              route,
-            );
-            break;
-
-          // ignore: no_default_cases
-          default:
-            context.router.replace(route);
-            break;
-        }
-      },
-      child: _CardWrapper(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Flexible(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Row(
-                      children: [
-                        Flexible(
-                          child: Text(
-                            counter.name,
-                            style: Theme.of(context).textTheme.headlineSmall,
-                          ),
+    return _CardWrapper(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          counter.name,
+                          style: Theme.of(context).textTheme.headlineSmall,
                         ),
-                      ],
-                    ),
-                    const SizedBox(
-                      height: 8,
-                    ),
-                    Text(
-                      counter.id,
-                      style: captionStyle.copyWith(
-                        color: Colors.grey,
                       ),
+                    ],
+                  ),
+                  const SizedBox(
+                    height: 8,
+                  ),
+                  Text(
+                    counter.id,
+                    style: captionStyle.copyWith(
+                      color: Colors.grey,
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-              Text(
-                '${counter.count}',
-                style: Theme.of(context).textTheme.headlineLarge,
-              ),
-            ],
-          ),
+            ),
+            Text(
+              '${counter.count}',
+              style: Theme.of(context).textTheme.headlineLarge,
+            ),
+          ],
         ),
       ),
     );

--- a/test/helpers/injectable.config.dart
+++ b/test/helpers/injectable.config.dart
@@ -139,17 +139,17 @@ Future<_i1.GetIt> init(
     preResolve: true,
   );
   await gh.factoryAsync<_i18.SharedPreferences>(
+    () => testModule.getPreferences(),
+    registerFor: {_tests},
+    preResolve: true,
+  );
+  await gh.factoryAsync<_i18.SharedPreferences>(
     () => genericModule.getPreferences(),
     registerFor: {
       _development,
       _staging,
       _production,
     },
-    preResolve: true,
-  );
-  await gh.factoryAsync<_i18.SharedPreferences>(
-    () => testModule.getPreferences(),
-    registerFor: {_tests},
     preResolve: true,
   );
   gh.factory<_i19.SplashCubit>(() => _i19.SplashCubit());

--- a/test/unit_test/presentation/counter_list/cubit/counter_list_cubit_test.dart
+++ b/test/unit_test/presentation/counter_list/cubit/counter_list_cubit_test.dart
@@ -225,4 +225,144 @@ void main() {
       );
     },
   );
+
+  group('toggle counter onTap', () {
+    blocTest(
+      'Given freshly loaded counter '
+      'when cubit was just initialized '
+      'then counter onTap should be enabled',
+      build: () => CounterListCubit(
+        watchCountersUseCase: watchCountersUseCase,
+        createCounterUseCase: createCounterUseCase,
+        incrementCounterUseCase: incrementCounterUseCase,
+        mapper: mapper,
+      ),
+      setUp: () {
+        final controller = BehaviorSubject<List<Counter>>()
+          ..add([
+            const Counter(id: 'id', name: 'name', count: 0),
+          ]);
+        when(watchCountersUseCase.watch()).thenAnswer(
+          (realInvocation) => controller.stream,
+        );
+      },
+      act: (bloc) async {
+        bloc.watchCounters();
+        await Future.delayed(const Duration(milliseconds: 32), () => null);
+      },
+      expect: () => [
+        const CounterListState.ready(
+          counters: [
+            UiCounter(id: 'id', name: 'name', count: 0),
+          ],
+          isCounterOnTapDisabled: false,
+        ),
+      ],
+    );
+
+    blocTest(
+      'Given counters are loading '
+      'when toggle is clicked '
+      'then nothing will happen',
+      build: () => CounterListCubit(
+        watchCountersUseCase: watchCountersUseCase,
+        createCounterUseCase: createCounterUseCase,
+        incrementCounterUseCase: incrementCounterUseCase,
+        mapper: mapper,
+      ),
+      act: (bloc) async {
+        await bloc.toggleCounterOnTapDisabled();
+      },
+      expect: () => [
+        const CounterListState.loading(counters: []),
+      ],
+    );
+
+    blocTest(
+      'Given counters are already loaded & onTap is enabled '
+      'when toggle is clicked '
+      'then ready state with onTap disabled should be emitted',
+      build: () => CounterListCubit(
+        watchCountersUseCase: watchCountersUseCase,
+        createCounterUseCase: createCounterUseCase,
+        incrementCounterUseCase: incrementCounterUseCase,
+        mapper: mapper,
+      ),
+      setUp: () {
+        final controller = BehaviorSubject<List<Counter>>()
+          ..add([
+            const Counter(id: 'id', name: 'name', count: 0),
+          ]);
+        when(watchCountersUseCase.watch()).thenAnswer(
+          (realInvocation) => controller.stream,
+        );
+      },
+      act: (bloc) async {
+        bloc.watchCounters();
+        await Future.delayed(const Duration(milliseconds: 32), () => null);
+        await bloc.toggleCounterOnTapDisabled();
+      },
+      expect: () => [
+        const CounterListState.ready(
+          counters: [
+            UiCounter(id: 'id', name: 'name', count: 0),
+          ],
+          isCounterOnTapDisabled: false,
+        ),
+        const CounterListState.ready(
+          counters: [
+            UiCounter(id: 'id', name: 'name', count: 0),
+          ],
+          isCounterOnTapDisabled: true,
+        ),
+      ],
+    );
+
+    blocTest(
+      'Given counters are already loaded & onTap is disabled '
+      'when toggle is clicked '
+      'then ready state with onTap enabled should be emitted',
+      build: () => CounterListCubit(
+        watchCountersUseCase: watchCountersUseCase,
+        createCounterUseCase: createCounterUseCase,
+        incrementCounterUseCase: incrementCounterUseCase,
+        mapper: mapper,
+      ),
+      setUp: () {
+        final controller = BehaviorSubject<List<Counter>>()
+          ..add([
+            const Counter(id: 'id', name: 'name', count: 0),
+          ]);
+        when(watchCountersUseCase.watch()).thenAnswer(
+          (realInvocation) => controller.stream,
+        );
+      },
+      act: (bloc) async {
+        bloc.watchCounters();
+        await Future.delayed(const Duration(milliseconds: 32), () => null);
+        await bloc.toggleCounterOnTapDisabled();
+        await bloc.toggleCounterOnTapDisabled();
+      },
+      expect: () => [
+        const CounterListState.ready(
+          counters: [
+            UiCounter(id: 'id', name: 'name', count: 0),
+          ],
+          isCounterOnTapDisabled: false,
+        ),
+        const CounterListState.ready(
+          counters: [
+            UiCounter(id: 'id', name: 'name', count: 0),
+          ],
+          isCounterOnTapDisabled: true,
+        ),
+        const CounterListState.ready(
+          counters: [
+            UiCounter(id: 'id', name: 'name', count: 0),
+          ],
+          isCounterOnTapDisabled: false,
+        ),
+      ],
+    );
+  });
 }

--- a/test/unit_test/presentation/counter_list/cubit/counter_list_cubit_test.dart
+++ b/test/unit_test/presentation/counter_list/cubit/counter_list_cubit_test.dart
@@ -82,6 +82,7 @@ void main() {
                 count: 0,
               ),
             ],
+            isCounterOnTapDisabled: false,
           ),
         ],
         verify: (_) {
@@ -126,6 +127,7 @@ void main() {
             counters: [
               UiCounter(id: 'id', name: 'name', count: 0),
             ],
+            isCounterOnTapDisabled: false,
           ),
         ],
         verify: (_) {
@@ -209,6 +211,7 @@ void main() {
             counters: [
               UiCounter(id: 'id', name: 'name', count: 1),
             ],
+            isCounterOnTapDisabled: false,
           ),
         ],
         verify: (_) {

--- a/test/widget_test/presentation/counter_list/view/counter_item_widget_test.dart
+++ b/test/widget_test/presentation/counter_list/view/counter_item_widget_test.dart
@@ -95,7 +95,7 @@ void main() {
     'Navigation',
     () {
       testWidgets(
-        'Given narrow screen '
+        'Given narrow screen and onTap is enabled '
         'when pressing item '
         'then tab is switched',
         (tester) async {
@@ -106,7 +106,9 @@ void main() {
               body: TabsRouterScope(
                 stateHash: 404,
                 controller: tabsRouter,
-                child: CounterItemWidget(counter: counter),
+                child: CounterItemWidget(
+                  counter: counter,
+                ),
               ),
             ),
             testRouter: router,
@@ -114,6 +116,32 @@ void main() {
           await tester.tap(itemFinder);
           await tester.pumpAndSettle();
           verify(tabsRouter.navigate(any));
+        },
+      );
+
+      testWidgets(
+        'Given narrow screen and onTap is disabled '
+        'when pressing item '
+        'then nothing happens',
+        (tester) async {
+          final itemFinder = find.byType(Card);
+          tester.setupNexusScreen();
+          await tester.pumpApp(
+            Scaffold(
+              body: TabsRouterScope(
+                stateHash: 404,
+                controller: tabsRouter,
+                child: CounterItemWidget(
+                  counter: counter,
+                  isOnTapDisabled: true,
+                ),
+              ),
+            ),
+            testRouter: router,
+          );
+          await tester.tap(itemFinder);
+          await tester.pumpAndSettle();
+          verifyNever(tabsRouter.navigate(any));
         },
       );
 

--- a/test/widget_test/presentation/counter_list/view/counter_list_page_test.dart
+++ b/test/widget_test/presentation/counter_list/view/counter_list_page_test.dart
@@ -281,6 +281,75 @@ void main() {
       );
     },
   );
+
+  group(
+    'Toggle counter onTap',
+    () {
+      setUp(
+        () {
+          when(
+            () => cubit.toggleCounterOnTapDisabled(),
+          ).thenAnswer((invocation) async {});
+        },
+      );
+
+      testWidgets(
+        'Given that counters are loading '
+        'when lock button is pressed '
+        'then toggle counter onTap is called ',
+        (tester) async {
+          const state = CounterListState.loading(counters: []);
+          whenListen(
+            cubit,
+            Stream.fromIterable([state]),
+            initialState: state,
+          );
+          final lockButtonFinder = find.byType(LockButton);
+
+          await _pumpView(
+            tester,
+            listView,
+            cubit,
+          );
+          await tester.tap(lockButtonFinder);
+
+          expect(lockButtonFinder, findsOneWidget);
+          verify(() => cubit.toggleCounterOnTapDisabled());
+        },
+      );
+
+      testWidgets(
+        'Given loaded counters list '
+        'when lock button is pressed '
+        'then toggle counter onTap is called ',
+        (tester) async {
+          final state = CounterListState.ready(
+            counters: shortCountersList,
+            isCounterOnTapDisabled: false,
+          );
+          whenListen(
+            cubit,
+            Stream.fromIterable([state]),
+            initialState: state,
+          );
+          final lockButtonFinder = find.byType(LockButton);
+
+          await _pumpView(
+            tester,
+            listView,
+            cubit,
+          );
+          await tester.tap(lockButtonFinder);
+          await tester.pumpAndSettle(
+            const Duration(milliseconds: 500),
+          );
+
+          expect(lockButtonFinder, findsOneWidget);
+          verify(() => cubit.toggleCounterOnTapDisabled());
+        },
+      );
+    },
+  );
 }
 
 Future<void> _pumpView(

--- a/test/widget_test/presentation/counter_list/view/counter_list_page_test.dart
+++ b/test/widget_test/presentation/counter_list/view/counter_list_page_test.dart
@@ -56,7 +56,10 @@ void main() {
         () async {
           router = getIt.get<AppRouter>();
           cubit = getIt.get<CounterListCubit>() as MockCounterListCubit;
-          const state = CounterListState.ready(counters: []);
+          const state = CounterListState.ready(
+            counters: [],
+            isCounterOnTapDisabled: false,
+          );
           whenListen(
             cubit,
             Stream.fromIterable([state]),
@@ -145,7 +148,10 @@ void main() {
         'when showing counter list '
         'then should inform user that there are no counters',
         (tester) async {
-          const state = CounterListState.ready(counters: []);
+          const state = CounterListState.ready(
+            counters: [],
+            isCounterOnTapDisabled: false,
+          );
           whenListen(
             cubit,
             Stream.fromIterable([state]),
@@ -176,6 +182,7 @@ void main() {
         (tester) async {
           final state = CounterListState.ready(
             counters: shortCountersList,
+            isCounterOnTapDisabled: false,
           );
           whenListen(
             cubit,
@@ -201,6 +208,7 @@ void main() {
         (tester) async {
           final state = CounterListState.ready(
             counters: longCountersList,
+            isCounterOnTapDisabled: false,
           );
           whenListen(
             cubit,
@@ -248,6 +256,7 @@ void main() {
         (tester) async {
           final state = CounterListState.ready(
             counters: shortCountersList,
+            isCounterOnTapDisabled: false,
           );
           whenListen(
             cubit,

--- a/test/widget_test/presentation/counter_list/view/multiple_tap_gesture_detector_test.dart
+++ b/test/widget_test/presentation/counter_list/view/multiple_tap_gesture_detector_test.dart
@@ -14,7 +14,10 @@ void main() {
 
   setUp(() {
     widget = MultipleTapGestureWrapper(
-      state: CounterListState.ready(counters: List.empty()),
+      state: CounterListState.ready(
+        counters: List.empty(),
+        isCounterOnTapDisabled: false,
+      ),
       child: const SizedBox(
         height: 512,
         width: 512,
@@ -23,11 +26,17 @@ void main() {
     cubit = MockCounterListCubit();
     whenListen(
       cubit,
-      Stream.fromIterable([
-        const CounterListState.ready(counters: []),
-      ]),
+      Stream.fromIterable(
+        [
+          const CounterListState.ready(
+            counters: [],
+            isCounterOnTapDisabled: false,
+          ),
+        ],
+      ),
       initialState: const CounterListState.ready(
         counters: [],
+        isCounterOnTapDisabled: false,
       ),
     );
     registerFallbackValue(cubit);

--- a/test/widget_test/presentation/dashboard/dashboard_page_test.dart
+++ b/test/widget_test/presentation/dashboard/dashboard_page_test.dart
@@ -31,8 +31,18 @@ void main() {
 
           whenListen(
             counterListCubit,
-            Stream.fromIterable([const CounterListState.ready(counters: [])]),
-            initialState: const CounterListState.ready(counters: []),
+            Stream.fromIterable(
+              [
+                const CounterListState.ready(
+                  counters: [],
+                  isCounterOnTapDisabled: false,
+                ),
+              ],
+            ),
+            initialState: const CounterListState.ready(
+              counters: [],
+              isCounterOnTapDisabled: false,
+            ),
           );
         },
       );


### PR DESCRIPTION
## Description

Toggle mode for counters list to either manipulate counters or allow user to navigate to counter details.

Icon is only visible on mobile platform since custom touch listener works only on that platform. 
Icon should change from open to close when navigation is enabled or disabled.
Tests were added to cover changes & updated roadmap.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
